### PR TITLE
Correct keyboard layout language name

### DIFF
--- a/Preferences/Keyboard.app/Keyboard
+++ b/Preferences/Keyboard.app/Keyboard
@@ -215,7 +215,7 @@ class KeyboardSwitcher(QtWidgets.QMainWindow):
         print(self.supported_layouts)
         cleartext = ["English (United States)", "English (United Kingdom)", "Français", "Español",
                      "Deutsch", "Italiano", "日本人", "Português", "Norsk",
-                     "Svenska", "Suomalainen", "Pусский", "Türk", "עִברִית"]
+                     "Svenska", "Suomalainen", "Pусский", "Türkçe", "עִברִית"]
         i = 0
         selected_index = -1
         for supported_layout in self.supported_layouts:


### PR DESCRIPTION
Türk is Turk/Turkish as in nationality, it's Türkçe for the language.