### PR TITLE
Merge File and Help menus together

### DIFF
--- a/Developer Preview/Energy Saving.app/Resources/energy-saving.py
+++ b/Developer Preview/Energy Saving.app/Resources/energy-saving.py
@@ -171,14 +171,14 @@ class EnergySavingsManager(object):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QtWidgets.QApplication.quit)
-        menubar = self.window.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QtWidgets.QAction('&About', self.window)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        fileMenu = menubar.addMenu('&Energy Saving')
+        fileMenu.addAction(aboutAct)
+        fileMenu.addAction(exitAct)
 
     def _showAbout(self):
         print("showDialog")

--- a/Developer Preview/Start Disk.app/Start Disk
+++ b/Developer Preview/Start Disk.app/Start Disk
@@ -184,14 +184,15 @@ class KeyboardSwitcher(QtWidgets.QMainWindow):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QtWidgets.QApplication.quit)
-        menubar = self.window.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QtWidgets.QAction('&About', self.window)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        menubar = self.window.menuBar()
+        fileMenu = menubar.addMenu('&Start Disk')
+        fileMenu.addAction(aboutAct)
+        helpMenu.addAction(exitAct)
 
 
     def _showAbout(self):

--- a/Preferences/Boot Environments.app/Resources/boot-environments.py
+++ b/Preferences/Boot Environments.app/Resources/boot-environments.py
@@ -526,14 +526,15 @@ Note that Boot Environments by default may not cover all locations, such as /hom
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QtWidgets.QApplication.quit)
-        menubar = self.window.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QtWidgets.QAction('&About', self.window)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        menubar = self.window.menuBar()
+        mainMenu = menubar.addMenu('&Boot Environments')
+        mainMenu.addAction(aboutAct)
+        mainMenu.addAction(exitAct)
 
     def _showAbout(self):
         print("showDialog")

--- a/Preferences/Keyboard.app/Keyboard
+++ b/Preferences/Keyboard.app/Keyboard
@@ -344,32 +344,27 @@ class KeyboardSwitcher(QtWidgets.QMainWindow):
  
     def _showMenu(self):
         menubar = self.window.menuBar()
-        fileMenu = menubar.addMenu('&File')
+        fileMenu = menubar.addMenu('&Keyboard')
         
         saveAct = QtWidgets.QAction('&Save', self.window)
         saveAct.setShortcut('Ctrl+S')
         saveAct.setStatusTip('Save settings to persist reboots')
         saveAct.triggered.connect(self.save)
         fileMenu.addAction(saveAct)
-        
         fileMenu.addSeparator()
+
+        aboutAct = QtWidgets.QAction('&About', self.window)
+        aboutAct.setStatusTip('About this application')
+        aboutAct.triggered.connect(self._showAbout)
+        fileMenu.addAction(aboutAct)
 
         exitAct = QtWidgets.QAction('&Quit', self.window)
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QtWidgets.QApplication.quit)
         fileMenu.addAction(exitAct)
-        
-        self.variantsMenu = menubar.addMenu('&Variants')
-        
-        helpMenu = menubar.addMenu('&Help')
-        
-        aboutAct = QtWidgets.QAction('&About', self.window)
-        aboutAct.setStatusTip('About this application')
-        aboutAct.triggered.connect(self._showAbout)
-        
-        helpMenu.addAction(aboutAct)
 
+        self.variantsMenu = menubar.addMenu('&Variants')
 
     def save(self):
         print("save called")

--- a/Preferences/Mouse.app/Mouse
+++ b/Preferences/Mouse.app/Mouse
@@ -146,14 +146,15 @@ class MouseWindow(QtWidgets.QMainWindow):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QtWidgets.QApplication.quit)
-        menubar = self.window.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QtWidgets.QAction('&About', self.window)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        menubar = self.window.menuBar()
+        fileMenu = menubar.addMenu('&Mouse')
+        fileMenu.addAction(aboutAct)
+        fileMenu.addAction(exitAct)
 
 
     def _showAbout(self):

--- a/Preferences/Users.app/Resources/adduser.py
+++ b/Preferences/Users.app/Resources/adduser.py
@@ -144,14 +144,15 @@ class Users(QMainWindow):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QApplication.quit)
-        menubar = self.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QAction('&About', self)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        menubar = self.menuBar()
+        fileMenu = menubar.addMenu('&Users')
+        fileMenu.addAction(aboutAct)
+        fileMenu.addAction(exitAct)
 
     def _showAbout(self):
         print("showDialog")

--- a/Utilities/Calculator.app/Resources/calculator.py
+++ b/Utilities/Calculator.app/Resources/calculator.py
@@ -141,15 +141,16 @@ class PyCalcUi(QMainWindow):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(qApp.quit)
-        menubar = self.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QAction('&About', self)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
-        
+
+        menubar = self.menuBar()
+        mainMenu = menubar.addMenu('&Calculator')
+        mainMenu.addAction(aboutAct)
+        mainMenu.addAction(exitAct)
+
     def _showAbout(self):
         print("showDialog")
         msg = QMessageBox()

--- a/Utilities/Calendar.app/Calendar.py
+++ b/Utilities/Calendar.app/Calendar.py
@@ -36,14 +36,15 @@ class Window(QMainWindow):
 		exitAct.setShortcut('Ctrl+Q')
 		exitAct.setStatusTip('Exit application')
 		exitAct.triggered.connect(qApp.quit)
-		menubar = self.menuBar()
-		fileMenu = menubar.addMenu('&File')
-		fileMenu.addAction(exitAct)
+
 		aboutAct = QAction('&About', self)
 		aboutAct.setStatusTip('About this application')
 		aboutAct.triggered.connect(self._showAbout)
-		helpMenu = menubar.addMenu('&Help')
-		helpMenu.addAction(aboutAct)
+
+		menubar = self.menuBar()
+		mainMenu = menubar.addMenu('&Calendar')
+		mainMenu.addAction(aboutAct)
+		mainMenu.addAction(exitAct)
 
 	def _showAbout(self):
 		print("showDialog")

--- a/Utilities/Logs.app/Resources/logs.py
+++ b/Utilities/Logs.app/Resources/logs.py
@@ -90,14 +90,15 @@ class MyConsole(QMainWindow):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QApplication.quit)
-        menubar = self.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QAction('&About', self)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        menubar = self.menuBar()
+        mainMenu = menubar.addMenu('&Logs')
+        mainMenu.addAction(aboutAct)
+        mainMenu.addAction(exitAct)
 
     def _showAbout(self):
         print("showDialog")

--- a/Utilities/Remote Assistance.app/Resources/remote_assistance.py
+++ b/Utilities/Remote Assistance.app/Resources/remote_assistance.py
@@ -279,20 +279,23 @@ class Window(QtWidgets.QMainWindow):
         giveAct.setShortcut('Ctrl+G')
         giveAct.setStatusTip('Give Assistance')
         giveAct.triggered.connect(self.giveAssistance)
+
         exitAct = QtWidgets.QAction('&Quit', self)
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QtWidgets.QApplication.quit)
-        menubar = self.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(giveAct)
-        fileMenu.addAction(exitAct)
+
         aboutAct = QtWidgets.QAction('&About', self)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
+
+        menubar = self.menuBar()
+        helpMenu = menubar.addMenu('&Remote Assistance')
+        helpMenu.addAction(giveAct)
+        helpMenu.addSeparator()
         helpMenu.addAction(aboutAct)
-        
+        helpMenu.addAction(exitAct)
+
     def _showAbout(self):
         print("showDialog")
         msg = QtWidgets.QMessageBox()

--- a/Utilities/Remote Assistance.app/Resources/remote_assistance_client.py
+++ b/Utilities/Remote Assistance.app/Resources/remote_assistance_client.py
@@ -253,14 +253,15 @@ class Window(QtWidgets.QMainWindow):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(QtWidgets.QApplication.quit)
-        menubar = self.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QtWidgets.QAction('&About', self)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        menubar = self.menuBar()
+        mainMenu = menubar.addMenu('&Remote Assistance')
+        mainMenu.addAction(aboutAct)
+        mainMenu.addAction(exitAct)
         
     def _showAbout(self):
         print("showDialog")

--- a/Utilities/Zeroconf.app/Zeroconf
+++ b/Utilities/Zeroconf.app/Zeroconf
@@ -279,14 +279,15 @@ class ZeroconfBrowser(object):
         exitAct.setShortcut('Ctrl+Q')
         exitAct.setStatusTip('Exit application')
         exitAct.triggered.connect(sys.exit, 0)
-        menubar = self.window.menuBar()
-        fileMenu = menubar.addMenu('&File')
-        fileMenu.addAction(exitAct)
+
         aboutAct = QtWidgets.QAction('&About', self.window)
         aboutAct.setStatusTip('About this application')
         aboutAct.triggered.connect(self._showAbout)
-        helpMenu = menubar.addMenu('&Help')
-        helpMenu.addAction(aboutAct)
+
+        menubar = self.window.menuBar()
+        mainMenu = menubar.addMenu('&Browser')
+        mainMenu.addAction(aboutAct)
+        mainMenu.addAction(exitAct)
 
 
     def _showAbout(self):


### PR DESCRIPTION
If any app had a File menu containing only a Quit command, and a Help menu containing only an About command, the two have been merged into one. The new menu is named after the applet it is part of. This change makes the applets look more polished IMHO. I have ran every applet changed and verified that everything works.