### PR TITLE
Make Calendar.app window resizable

### DIFF
--- a/Utilities/Calendar.app/Calendar.py
+++ b/Utilities/Calendar.app/Calendar.py
@@ -27,9 +27,21 @@ class Window(QMainWindow):
 		super().__init__()
 		self.setWindowTitle("Calendar")
 		c = Calendar()
+		self.c = c
 		self.setCentralWidget(c)
 		self._showMenu()
-		self.setMinimumSize(255, 225) # FIXME: Make this adjust to the widgets size automatically
+		self.setMinimumSize(255, 225)
+		self.resizeEvent = self._resizeEvent
+
+	def _resizeEvent(self, event):
+		# change the header format depending on the width of the window
+		if(event.size().width() < 350):
+			self.c.calendar.setHorizontalHeaderFormat(QCalendarWidget.SingleLetterDayNames)
+		else:
+			self.c.calendar.setHorizontalHeaderFormat(QCalendarWidget.ShortDayNames)
+		
+		# update calendar geometry
+		self.c.calendar.setGeometry(0, 0, event.size().width(), event.size().height())
 
 	def _showMenu(self):
 		exitAct = QAction('&Exit', self)


### PR DESCRIPTION
On MacOS, the resiable Calendar.app looks like this:
![image](https://github.com/helloSystem/Utilities/assets/146669165/9e21834d-48d8-4d58-a64d-be186da6f100)
![image](https://github.com/helloSystem/Utilities/assets/146669165/7bc5e0ab-8f10-4cee-aea5-bf2ede226f9e)
